### PR TITLE
Fix InvalidCastException and PostgreSQL transaction abort in HTTP sync

### DIFF
--- a/src/CoreSync.Http.Client/Implementation/SyncProviderHttpClient.cs
+++ b/src/CoreSync.Http.Client/Implementation/SyncProviderHttpClient.cs
@@ -216,16 +216,17 @@ internal class SyncProviderHttpClient : ISyncProviderHttpClient
         {
             foreach (var itemValueEntry in item.Values.Where(_ => _.Key != "__OP").ToList())
             {
-                item.Values[itemValueEntry.Key].Value = itemValueEntry.Value.Value == null ? null :
-                    ConvertJsonValueToNetObject((JsonElement)itemValueEntry.Value.Value, itemValueEntry.Value.Type);
-
-                //WARN: can't convert every Id to lowercase because sqlite is case sensitive!
-                //if (itemValueEntry.Value.Value != null &&
-                //    itemValueEntry.Value.Type == SyncItemValueType.String &&
-                //    (itemValueEntry.Key == "Id" || itemValueEntry.Key.EndsWith("Id")))
-                //{
-                //    item.Values[itemValueEntry.Key].Value = itemValueEntry.Value.Value.ToString().ToLowerInvariant();
-                //}
+                var rawValue = itemValueEntry.Value.Value;
+                if (rawValue == null)
+                {
+                    item.Values[itemValueEntry.Key].Value = null;
+                }
+                else if (rawValue is JsonElement jsonElement)
+                {
+                    item.Values[itemValueEntry.Key].Value =
+                        ConvertJsonValueToNetObject(jsonElement, itemValueEntry.Value.Type);
+                }
+                // else: value is already a native .NET type — no conversion needed.
             }
         }
     }

--- a/src/CoreSync.Http.Server/SyncAgentController.cs
+++ b/src/CoreSync.Http.Server/SyncAgentController.cs
@@ -170,8 +170,18 @@ class SyncAgentController
             {
                 foreach (var itemValueEntry in item.Values.Where(_ => _.Key != "__OP").ToList())
                 {
-                    item.Values[itemValueEntry.Key].Value = itemValueEntry.Value.Value == null ? null :
-                        ConvertJsonElementToObject((JsonElement)itemValueEntry.Value.Value, itemValueEntry.Value.Type);
+                    var rawValue = itemValueEntry.Value.Value;
+                    if (rawValue == null)
+                    {
+                        item.Values[itemValueEntry.Key].Value = null;
+                    }
+                    else if (rawValue is JsonElement jsonElement)
+                    {
+                        item.Values[itemValueEntry.Key].Value =
+                            ConvertJsonElementToObject(jsonElement, itemValueEntry.Value.Type);
+                    }
+                    // else: value is already a native .NET type (e.g. from MessagePack deserialization
+                    // or newer System.Text.Json versions) — no conversion needed.
                 }
             }
 

--- a/src/CoreSync.PostgreSQL/PostgreSQLSyncProvider.cs
+++ b/src/CoreSync.PostgreSQL/PostgreSQLSyncProvider.cs
@@ -84,12 +84,18 @@ namespace CoreSync.PostgreSQL
 
                     try
                     {
+                        // Use a savepoint so that a failed statement does not abort
+                        // the entire PostgreSQL transaction (error state 25P02).
+                        await tr.SaveAsync("sync_item", cancellationToken);
+
                         affectedRows = await cmd.ExecuteNonQueryAsync(cancellationToken);
 
                         if (affectedRows > 0)
                         {
                             _logger?.Trace($"[{_storeId}] Successfully applied {item}");
                         }
+
+                        await tr.ReleaseAsync("sync_item", cancellationToken);
                     }
                     catch (OperationCanceledException)
                     {
@@ -98,6 +104,9 @@ namespace CoreSync.PostgreSQL
                     catch (Exception ex)
                     {
                         _logger?.Error($"Unable to {itemChangeType} item {item} to store for table {table}.{Environment.NewLine}{ex}{Environment.NewLine}Generated SQL:{Environment.NewLine}{cmd.CommandText}");
+                        // Rollback to the savepoint so the transaction can continue
+                        // processing remaining items.
+                        try { await tr.RollbackAsync("sync_item", cancellationToken); } catch { /* already rolled back */ }
                     }
 
                     if (affectedRows == 0)


### PR DESCRIPTION
## Problem

When using the HTTP sync protocol with a PostgreSQL server and SQLite mobile clients (mixed-provider sync), two bugs cause server-side failures:

### Bug 1: InvalidCastException in CompleteApplyBulkChangesAsync

```
System.InvalidCastException: Unable to cast object of type 'System.String' to type 'System.Text.Json.JsonElement'
   at CoreSync.Http.Server.SyncAgentController.CompleteApplyBulkChangesAsync(Guid sessionId)
```

**Root cause:** `CompleteApplyBulkChangesAsync` (line 174) hard-casts `itemValueEntry.Value.Value` to `JsonElement`, but values may already be native .NET types. This happens when:
- MessagePack deserialization returns native types instead of `JsonElement`
- Newer versions of `System.Text.Json` (e.g., .NET 10) may deserialize `object?` properties differently

**Fix:** Use pattern matching (`is JsonElement`) instead of a hard cast. If the value is already a native .NET type, skip the conversion.

### Bug 2: PostgreSQL transaction abort (25P02)

```
Npgsql.PostgresException: 25P02: current transaction is aborted, commands ignored until end of transaction block
```

**Root cause:** In `PostgreSQLSyncProvider.ApplyChangesAsync`, when a DML statement fails (e.g., FK constraint violation), the exception is caught and logged, but the transaction continues. Unlike SQLite, PostgreSQL enters an "aborted" state after any error within a transaction — all subsequent commands are rejected with error 25P02.

**Fix:** Wrap each DML operation in a `SAVEPOINT`. On failure, rollback to the savepoint so the transaction remains usable for subsequent items. This matches the SQLite provider's behavior of skipping failed items gracefully.

## Reproduction

1. Set up a PostgreSQL server with CoreSync HTTP endpoints
2. Set up a SQLite mobile client (e.g., .NET MAUI app)
3. Populate the mobile client with data
4. Trigger sync from mobile → server

**Expected:** Sync completes successfully
**Actual:** Server crashes with InvalidCastException, and any SQL errors cascade into 25P02

## Changes

| File | Change |
|------|--------|
| `SyncAgentController.cs` | Pattern match `is JsonElement` instead of hard cast in `CompleteApplyBulkChangesAsync` |
| `SyncProviderHttpClient.cs` | Same fix in client-side `ConvertJsonValueToNetObject` for robustness |
| `PostgreSQLSyncProvider.cs` | Wrap DML in `SAVEPOINT`/`RELEASE`/`ROLLBACK TO SAVEPOINT` for error recovery |

## Testing

Verified end-to-end with:
- **Server:** .NET 10 API with PostgreSQL (via Aspire), CoreSync.Http.Server + CoreSync.PostgreSQL
- **Client:** .NET MAUI Mac Catalyst app with SQLite, CoreSync.Http.Client + CoreSync.Sqlite
- Sync of ~12K rows completes successfully with these fixes applied
