### PR TITLE
Update target frameworks and add more test platforms

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   build-and-test:
+    strategy:
+      matrix:
+        tfm: [net10.0, net9.0, net8.0]
+
     runs-on: ubuntu-latest
 
     services:
@@ -49,7 +53,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore src/CoreSync.sln
@@ -58,7 +65,7 @@ jobs:
         run: dotnet build src/CoreSync.sln --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test src/CoreSync.sln --configuration Release --no-restore --no-build --verbosity normal
+        run: dotnet test src/CoreSync.sln --configuration Release --no-restore --no-build  --framework ${{ matrix.tfm }} --verbosity normal
 
   publish:
     needs: build-and-test
@@ -71,7 +78,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Extract version from tag
         id: version

--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ SyncAgent.SynchronizeAsync()
 
 ## Target Frameworks
 
-- **Core library and providers**: .NET Standard 2.0 (compatible with .NET Framework 4.6.1+ and .NET Core 2.0+)
-- **HTTP packages**: .NET 8.0
+- **Core library and providers**: .NET 8.0+ (compatible with .NET 10/9)
+- **Tested on**: .NET 10/9/8
 
 ## Sample App
 

--- a/src/CoreSync.Http.Client/CoreSync.Http.Client.csproj
+++ b/src/CoreSync.Http.Client/CoreSync.Http.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' == '' ">0.0.1-local</Version>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' != '' ">$(APPVEYOR_BUILD_VERSION)</Version>
-    <TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <Authors>adospace</Authors>
     <Description>CoreSync is a .NET standard library that provides data synchronization functions between databases. Currently Sql Server and SQLite are supported. This is the Http client package.</Description>
     <Copyright>Adolfo Marinucci</Copyright>
@@ -26,8 +26,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
-    <PackageReference Include="MessagePack" Version="2.5.187" />
-    <PackageReference Include="Polly.Core" Version="8.5.0" />
+    <PackageReference Include="MessagePack" Version="3.1.4" />
+    <PackageReference Include="Polly.Core" Version="8.6.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreSync.Http.Server/CoreSync.Http.Server.csproj
+++ b/src/CoreSync.Http.Server/CoreSync.Http.Server.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="MessagePack.AspNetCoreMvcFormatter" Version="2.5.187" />
+    <PackageReference Include="MessagePack.AspNetCoreMvcFormatter" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreSync.Http/CoreSync.Http.csproj
+++ b/src/CoreSync.Http/CoreSync.Http.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' == '' ">0.0.1-local</Version>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' != '' ">$(APPVEYOR_BUILD_VERSION)</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <Authors>adospace</Authors>
     <Description>CoreSync is a .NET standard library that provides data synchronization functions between databases. Currently Sql Server and SQLite are supported. This is the Http common package.</Description>
     <Copyright>Adolfo Marinucci</Copyright>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.5.187" />
+    <PackageReference Include="MessagePack" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreSync.PostgreSQL/CoreSync.PostgreSQL.csproj
+++ b/src/CoreSync.PostgreSQL/CoreSync.PostgreSQL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' == '' ">0.0.1-local</Version>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' != '' ">$(APPVEYOR_BUILD_VERSION)</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <Authors>adospace</Authors>
     <Description>CoreSync is a .NET standard library that provides data synchronization functions between databases. This is the PostgreSQL provider assembly.</Description>
     <Copyright>Adolfo Marinucci</Copyright>
@@ -29,8 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="8.0.5" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="Npgsql" Version="8.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreSync.PostgreSQL/PostgreSQLSyncConfigurationBuilder.cs
+++ b/src/CoreSync.PostgreSQL/PostgreSQLSyncConfigurationBuilder.cs
@@ -118,7 +118,7 @@ namespace CoreSync.PostgreSQL
         {
             if (name == null)
             {
-                var tableAttribute = (TableAttribute)Attribute.GetCustomAttribute(typeof(T), typeof(TableAttribute));
+                var tableAttribute = (TableAttribute?)Attribute.GetCustomAttribute(typeof(T), typeof(TableAttribute));
                 if (tableAttribute != null)
                     name = tableAttribute.Name;
             }

--- a/src/CoreSync.PostgreSQL/PostgreSQLSyncProvider.cs
+++ b/src/CoreSync.PostgreSQL/PostgreSQLSyncProvider.cs
@@ -71,7 +71,7 @@ namespace CoreSync.PostgreSQL
 
                     foreach (var item in remainingItems)
                     {
-                        var table = (PostgreSQLSyncTable)Configuration.Tables.FirstOrDefault(_ => _.Name == item.TableName);
+                        var table = (PostgreSQLSyncTable?)Configuration.Tables.FirstOrDefault(_ => _.Name == item.TableName);
                         if (table == null)
                         {
                             continue;
@@ -352,13 +352,13 @@ namespace CoreSync.PostgreSQL
                     {
                         cmd.CommandText = table.IncrementalAddOrUpdatesQuery;
                         cmd.Parameters.Clear();
-                        
+
                         // Add filter parameters first (for custom selectIncrementalQuery)
                         foreach (var syncFilterParameter in syncFilterParameters)
                         {
                             cmd.Parameters.Add(new NpgsqlParameter { Value = syncFilterParameter.Value });
                         }
-                        
+
                         // Then add incremental query parameters
                         cmd.Parameters.Add(new NpgsqlParameter { Value = fromAnchor.Version });
                         cmd.Parameters.Add(new NpgsqlParameter { Value = table.Name });
@@ -732,7 +732,7 @@ CREATE TRIGGER __{table.Name}_ct_{op.ToLower()}__
                 await DisableChangeTrackingForTable(cmd, table.Name, cancellationToken);
             }
         }
-        
+
         public async Task<SyncVersion> GetSyncVersionAsync(CancellationToken cancellationToken = default)
         {
             await InitializeStoreAsync(cancellationToken);
@@ -836,7 +836,7 @@ CREATE TRIGGER __{table.Name}_ct_{op.ToLower()}__
                 await SetupTableForUpdatesOrDeletesOnly(table, cmd, cancellationToken);
             }
         }
-         
+
         public async Task DisableChangeTrackingForTable(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
@@ -853,7 +853,7 @@ CREATE TRIGGER __{table.Name}_ct_{op.ToLower()}__
         }
 
         private async Task DisableChangeTrackingForTable(NpgsqlCommand cmd, string tableName, CancellationToken cancellationToken)
-        { 
+        {
             var dropTriggerAndFunctionBase = new Func<string, string>((op) => $@"
 DROP TRIGGER IF EXISTS __{tableName}_ct_{op.ToLower()}__ ON ""{tableName}"";
 DROP FUNCTION IF EXISTS __{tableName}_ct_{op.ToLower()}__();");
@@ -865,8 +865,8 @@ DROP FUNCTION IF EXISTS __{tableName}_ct_{op.ToLower()}__();");
             await cmd.ExecuteNonQueryAsync();
 
             cmd.CommandText = dropTriggerAndFunctionBase("DELETE");
-            await cmd.ExecuteNonQueryAsync();        
+            await cmd.ExecuteNonQueryAsync();
         }
 
     }
-} 
+}

--- a/src/CoreSync.SqlServer/CoreSync.SqlServer.csproj
+++ b/src/CoreSync.SqlServer/CoreSync.SqlServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' == '' ">0.0.1-local</Version>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' != '' ">$(APPVEYOR_BUILD_VERSION)</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <Authors>adospace</Authors>
     <Description>CoreSync is a .NET standard library that provides data synchronization functions between databases. This is the Sql Server provider assembly.</Description>
     <Copyright>Adolfo Marinucci</Copyright>
@@ -29,10 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreSync.SqlServer/SqlCommandExtensions.cs
+++ b/src/CoreSync.SqlServer/SqlCommandExtensions.cs
@@ -1,8 +1,6 @@
 ﻿
 using Microsoft.Data.SqlClient;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,7 +13,7 @@ namespace CoreSync.SqlServer
             long version = 0;
             var res = await cmd.ExecuteScalarAsync();
             if (!(res is DBNull))
-                version = (long)res;
+                version = (long)res!;
 
             return version;
         }

--- a/src/CoreSync.SqlServer/SqlSyncConfigurationBuilder.cs
+++ b/src/CoreSync.SqlServer/SqlSyncConfigurationBuilder.cs
@@ -134,7 +134,7 @@ namespace CoreSync.SqlServer
             string? customSnapshotQuery = null)
         {
             var name = typeof(T).Name;
-            var tableAttribute = (TableAttribute)Attribute.GetCustomAttribute(typeof(T), typeof(TableAttribute));
+            var tableAttribute = (TableAttribute?)Attribute.GetCustomAttribute(typeof(T), typeof(TableAttribute));
             if (tableAttribute != null)
             {
                 name = tableAttribute.Name;

--- a/src/CoreSync.SqlServer/SqlSyncProvider.cs
+++ b/src/CoreSync.SqlServer/SqlSyncProvider.cs
@@ -2,10 +2,8 @@
 using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
 using System.Data;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -87,7 +85,7 @@ namespace CoreSync.SqlServer
 
                         foreach (var item in remainingItems)
                         {
-                            var table = (SqlSyncTable)Configuration.Tables.FirstOrDefault(_ => _.Name == item.TableName);
+                            var table = (SqlSyncTable?)Configuration.Tables.FirstOrDefault(_ => _.Name == item.TableName);
 
                             if (table == null)
                             {

--- a/src/CoreSync.SqlServer/Utils.cs
+++ b/src/CoreSync.SqlServer/Utils.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
-using System.Text;
 
 namespace CoreSync.SqlServer
 {
@@ -15,7 +13,7 @@ namespace CoreSync.SqlServer
 
             if (dbType == SqlDbType.UniqueIdentifier &&
                 value.Value is string)
-                return Guid.Parse(value.Value.ToString());
+                return Guid.Parse(value.Value.ToString()!);
 
             if (dbType == SqlDbType.Decimal &&
                 value.Value is decimal == false)

--- a/src/CoreSync.SqlServerCT/CoreSync.SqlServerCT.csproj
+++ b/src/CoreSync.SqlServerCT/CoreSync.SqlServerCT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' == '' ">0.0.1-local</Version>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' != '' ">$(APPVEYOR_BUILD_VERSION)</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <Authors>adospace</Authors>
     <Description>CoreSync is a .NET standard library that provides data synchronization functions between databases. This is the Sql Server Change Tracking provider assembly.</Description>
     <Copyright>Adolfo Marinucci</Copyright>
@@ -29,10 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreSync.SqlServerCT/SqlServerCTProvider.cs
+++ b/src/CoreSync.SqlServerCT/SqlServerCTProvider.cs
@@ -72,7 +72,7 @@ namespace CoreSync.SqlServerCT
 
                         foreach (var item in remainingItems)
                         {
-                            var table = (SqlServerCTSyncTable)Configuration.Tables.FirstOrDefault(_ => _.Name == item.TableName);
+                            var table = (SqlServerCTSyncTable?)Configuration.Tables.FirstOrDefault(_ => _.Name == item.TableName);
 
                             if (table == null)
                             {

--- a/src/CoreSync.SqlServerCT/SqlServerCTSyncConfigurationBuilder.cs
+++ b/src/CoreSync.SqlServerCT/SqlServerCTSyncConfigurationBuilder.cs
@@ -150,7 +150,7 @@ namespace CoreSync.SqlServerCT
             string? customSnapshotQuery = null)
         {
             var name = typeof(T).Name;
-            var tableAttribute = (TableAttribute)Attribute.GetCustomAttribute(typeof(T), typeof(TableAttribute));
+            var tableAttribute = (TableAttribute?)Attribute.GetCustomAttribute(typeof(T), typeof(TableAttribute));
             if (tableAttribute != null)
             {
                 name = tableAttribute.Name;

--- a/src/CoreSync.SqlServerCT/Utils.cs
+++ b/src/CoreSync.SqlServerCT/Utils.cs
@@ -13,7 +13,7 @@ namespace CoreSync.SqlServerCT
 
             if (dbType == SqlDbType.UniqueIdentifier &&
                 value.Value is string)
-                return Guid.Parse(value.Value.ToString());
+                return Guid.Parse(value.Value.ToString()!);
 
             if (dbType == SqlDbType.Decimal &&
                 value.Value is decimal == false)

--- a/src/CoreSync.Sqlite/CoreSync.Sqlite.csproj
+++ b/src/CoreSync.Sqlite/CoreSync.Sqlite.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' == '' ">0.0.1-local</Version>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' != '' ">$(APPVEYOR_BUILD_VERSION)</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <Authors>adospace</Authors>
     <Description>CoreSync is a .NET standard library that provides data synchronization functions between databases. This is the SQLite provider assembly.</Description>
     <Copyright>Adolfo Marinucci</Copyright>
@@ -29,8 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreSync.Sqlite/SqliteCommandExtensions.cs
+++ b/src/CoreSync.Sqlite/SqliteCommandExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Data.Sqlite;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,7 +12,7 @@ namespace CoreSync.Sqlite
             long version = 0;
             var res = await cmd.ExecuteScalarAsync(cancellationToken);
             if (!(res is DBNull))
-                version = (long)res;
+                version = (long)res!;
 
             return version;
         }

--- a/src/CoreSync.Sqlite/SqliteSyncConfigurationBuilder.cs
+++ b/src/CoreSync.Sqlite/SqliteSyncConfigurationBuilder.cs
@@ -116,7 +116,7 @@ namespace CoreSync.Sqlite
         {
             if (name == null)
             {
-                var tableAttribute = (TableAttribute)Attribute.GetCustomAttribute(typeof(T), typeof(TableAttribute));
+                var tableAttribute = (TableAttribute?)Attribute.GetCustomAttribute(typeof(T), typeof(TableAttribute));
                 if (tableAttribute != null)
                     name = tableAttribute.Name;
             }

--- a/src/CoreSync.Sqlite/SqliteSyncProvider.cs
+++ b/src/CoreSync.Sqlite/SqliteSyncProvider.cs
@@ -71,7 +71,7 @@ namespace CoreSync.Sqlite
 
                     foreach (var item in remainingItems)
                     {
-                        var table = (SqliteSyncTable)Configuration.Tables.FirstOrDefault(_ => _.Name == item.TableName);
+                        var table = (SqliteSyncTable?)Configuration.Tables.FirstOrDefault(_ => _.Name == item.TableName);
                         if (table == null)
                         {
                             continue;
@@ -126,7 +126,7 @@ namespace CoreSync.Sqlite
                                 cmd.Parameters.Clear();
                                 var valueItem = item.Values[table.PrimaryColumnName];
                                 cmd.Parameters.Add(new SqliteParameter("@PrimaryColumnParameter", valueItem.Value ?? DBNull.Value));
-                                if (1 == (long)await cmd.ExecuteScalarAsync(cancellationToken) && !syncForceWrite)
+                                if (1 == (long?)await cmd.ExecuteScalarAsync(cancellationToken) && !syncForceWrite)
                                 {
                                     itemChangeType = ChangeType.Update;
                                     goto retryWrite;
@@ -742,7 +742,7 @@ namespace CoreSync.Sqlite
                 await DisableChangeTrackingForTable(cmd, tableName, cancellationToken);
             }
         }
-        
+
         public async Task<SyncVersion> GetSyncVersionAsync(CancellationToken cancellationToken = default)
         {
             await InitializeStoreAsync(cancellationToken);
@@ -844,7 +844,7 @@ namespace CoreSync.Sqlite
                 await SetupTableForUpdatesOrDeletesOnly(table, cmd, cancellationToken);
             }
         }
-         
+
         public async Task DisableChangeTrackingForTable(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
@@ -861,7 +861,7 @@ namespace CoreSync.Sqlite
         }
 
         private async Task DisableChangeTrackingForTable(SqliteCommand cmd, string tableName, CancellationToken cancellationToken)
-        { 
+        {
             var commandTextBase = new Func<string, string>((op) => $@"DROP TRIGGER IF EXISTS [__{tableName}_ct-{op}__]");
             cmd.CommandText = commandTextBase("INSERT");
             await cmd.ExecuteNonQueryAsync();
@@ -870,7 +870,7 @@ namespace CoreSync.Sqlite
             await cmd.ExecuteNonQueryAsync();
 
             cmd.CommandText = commandTextBase("DELETE");
-            await cmd.ExecuteNonQueryAsync();        
+            await cmd.ExecuteNonQueryAsync();
         }
 
     }

--- a/src/CoreSync.Tests/CoreSync.Tests.csproj
+++ b/src/CoreSync.Tests/CoreSync.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>RS1036,NU1903,NU1902,NU1901,NU1904</NoWarn>
     <Nullable>enable</Nullable>
@@ -14,21 +14,32 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.27">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
   </ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.27" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.16" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\CoreSync.Sqlite\CoreSync.Sqlite.csproj" />

--- a/src/CoreSync/CoreSync.csproj
+++ b/src/CoreSync/CoreSync.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' == '' ">0.0.1-local</Version>
     <Version Condition=" '$(APPVEYOR_BUILD_VERSION)' != '' ">$(APPVEYOR_BUILD_VERSION)</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <Authors>adospace</Authors>
     <Description>CoreSync is a .NET standard library that provides data synchronization functions between databases. Currently Sql Server and SQLite are supported.</Description>
     <Copyright>Adolfo Marinucci</Copyright>
@@ -25,6 +25,6 @@
   </PropertyGroup>
 
     <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
   </ItemGroup>
 </Project>

--- a/src/CoreSync/SyncItem.cs
+++ b/src/CoreSync/SyncItem.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace CoreSync
 {
@@ -64,7 +63,7 @@ namespace CoreSync
             if (syncItemValue.Type == SyncItemValueType.String)
                 return $"\"{syncItemValue.Value}\"";
 
-            return syncItemValue.Value.ToString();
+            return syncItemValue.Value.ToString()!;
         }
     }
 }

--- a/src/CoreSync/SynchronizationException.cs
+++ b/src/CoreSync/SynchronizationException.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text;
 
 namespace CoreSync
 {
@@ -16,10 +13,6 @@ namespace CoreSync
         }
 
         public SynchronizationException(string message, Exception innerException) : base($"{message}: {innerException.Message}", innerException)
-        {
-        }
-
-        protected SynchronizationException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }


### PR DESCRIPTION
Changes:
- Update target frameworks: .NET 8
- Update test platforms: .NET 10, .NET 9, .NET 8
- Update dependencies. Some dependencies were removed (they are included in .NET 8+ by default) 
- (Breaking change) No longer support .NET Framework and < .NET 8 platforms